### PR TITLE
Use a newer docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-# https://github.com/pipe-cd/pipecd/pkgs/container/actions-plan-preview/155479628?tag=v0.46.0-rc0-10-g2501848
-FROM ghcr.io/pipe-cd/actions-plan-preview@sha256:e1cdb4c97c2ffa39c04c944cb73b3b32b47407d8403e599cb58b9a5ed9fcda7c
+# https://github.com/pipe-cd/pipecd/pkgs/container/actions-plan-preview/268616488?tag=v0.48.0-118-g25e9a71
+FROM ghcr.io/pipe-cd/actions-plan-preview@sha256:ac2bf7260c6103ba9561fd021c19964e6a1a6727aee2449b6b3c29862bf88537


### PR DESCRIPTION
To apply [Improve Terraform plan result handling #5177](https://github.com/pipe-cd/pipecd/pull/5177), change the docker image to a newer one.