### PR TITLE
Add `sort-label-keys`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,6 @@ jobs:
 | address                         | The API address of PipeCD's control-plane.                                                        |    yes   |               |
 | api-key                         | The API key with READ_WRITE role used by pipectl while communicating with PipeCD's control-plane. |    yes   |               |
 | token                           | The GITHUB_TOKEN secret.                                                                          |    yes   |               |
+| timeout                         | Maximum amount of time to run.                                                                    |    no    | 5m            |
+| piped-handle-timeout            | Maximum amount of time to wait for piped handle the plan preview.                                 |    no    | 5m            |
+| sort-label-keys                 | The application label keys to sort the results by.                                                |    no    | ""            |

--- a/action.yaml
+++ b/action.yaml
@@ -20,6 +20,10 @@ inputs:
     description: 'Maximum amount of time to wait for piped handle the plan preview. Default is 5m.'
     required: false
     default: 5m
+  sort-label-keys:
+    description: 'The application label keys to sort the results by. If not specified, the results will be sorted by only PipedID and ApplicationName.'
+    required: false
+    default: ''
 
 runs:
   using: 'docker'
@@ -30,6 +34,7 @@ runs:
     - token=${{ inputs.token }}
     - timeout=${{ inputs.timeout }}
     - piped-handle-timeout=${{ inputs.piped-handle-timeout }}
+    - sort-label-keys=${{ inputs.sort-label-keys }}
 
 branding:
   icon: 'eye'


### PR DESCRIPTION
### What this PR does:
Adds the `sort-label-keys` input, related to [pipecd/pipecd#5540](https://github.com/pipe-cd/pipecd/pull/5540).

### TODO:

Once the `sort-label-keys` feature is released, update the Docker image version, as in:

[pipe-cd/actions-plan-preview#17](https://github.com/pipe-cd/actions-plan-preview/pull/17).