### PR TITLE
Update base image to v0.50.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-# https://github.com/pipe-cd/pipecd/pkgs/container/actions-plan-preview/268616488?tag=v0.48.0-118-g25e9a71
-FROM ghcr.io/pipe-cd/actions-plan-preview@sha256:ac2bf7260c6103ba9561fd021c19964e6a1a6727aee2449b6b3c29862bf88537
+# https://github.com/pipe-cd/pipecd/pkgs/container/actions-plan-preview/356762350?tag=v0.50.2
+FROM ghcr.io/pipe-cd/actions-plan-preview@sha256:b7ffd4da57df2fba144d5b5a61f5bff8b9690f6956f909bf615340c4c59dcc28


### PR DESCRIPTION
To use this feature of pipectl v0.50.2 : https://github.com/pipe-cd/pipecd/pull/5540



Check here for sha: https://github.com/pipe-cd/pipecd/pkgs/container/actions-plan-preview/356762350?tag=v0.50.2